### PR TITLE
Change the url for Thermo Fisher Scientific.

### DIFF
--- a/data/vendor_urls.csv
+++ b/data/vendor_urls.csv
@@ -2,7 +2,7 @@ Vendor,URL
 BioLegend,https://www.biolegend.com/
 AAT Bioquest,https://www.aatbio.com/
 R&D Systems,https://www.rndsystems.com/
-Thermo Fisher Scientific,https://www.thermofisher.com/
+Thermo Fisher Scientific,https://www.thermofisher.com/us/en/home/life-science/antibodies.html
 Caprico Biotechnologies,https://www.capricobio.com/
 SouthernBiotech,https://www.southernbiotech.com/
 Abcam,https://www.abcam.com/


### PR DESCRIPTION
Previous link pointed to the main site, current link points directly to the antibody section.