### PR TITLE
Adding two bioRxiv publications.

### DIFF
--- a/data/publications.bib
+++ b/data/publications.bib
@@ -1,4 +1,26 @@
-@article {Yayon2023.10.25.562925,
+@article {kudo2023,
+	author = {Takamasa Kudo and Ana M. Meireles and Reuben Moncada and Yushu Chen and Ping Wu and Joshua Gould and Xiaoyu Hu and Opher Kornfeld and Rajiv Jesudason and Conrad Foo and Burkhard H{\"o}ckendorf and Hector Corrada Bravo and Jason P. Town and Runmin Wei and Antonio Rios and Vineethkrishna Chandrasekar and Melanie Heinlein and Shuangyi Cai and Cherry Sakura Lu and Cemre Celen and Noelyn Kljavin and Jian Jiang and Jose Sergio Hleap and Nobuhiko Kayagaki and Felipe de Sousa e Melo and Lisa McGinnis and Bo Li and Avtar Singh and Levi Garraway and Orit Rozenblatt-Rosen and Aviv Regev and Eric Lubeck},
+	title = {Highly multiplexed, image-based pooled screens in primary cells and tissues with {PerturbView}},
+	year = {2023},
+	doi = {10.1101/2023.12.26.573143},
+	journal = {bioRxiv},
+	note={Corresponding authors: \href{mailto:regeva@gene.com,lubecke@gene.com}{Aviv Regev, Eric Lubeck}},
+    keywords = {}
+}
+
+
+@article {gu2023,
+	author = {Jiacheng Gu and Abhishek Iyer and Ben Wesley and Angelo Taglialatela and Giuseppe Leuzzi and Sho Hangai and Aubrianna Decker and Ruoyu Gu and Naomi Klickstein and Yuanlong Shuai and Kristina Jankovic and Lucy Parker-Burns and Yinuo Jin and Jia Yi Zhang and Justin Hong and Steve Niu and Jacqueline Chou and Dan A. Landau and Elham Azizi and Edmond M. Chan and Alberto Ciccia and Jellert T. Gaublomme},
+	title = {{CRISPRmap}: Sequencing-free optical pooled screens mapping multi-omic phenotypes in cells and tissue},
+	year = {2023},
+	doi = {10.1101/2023.12.26.572587},
+	journal = {bioRxiv},
+	note={Corresponding authors: \href{mailto:jg4106@columbia.edu}{Jellert T. Gaublomme}},
+	keywords = {}
+}
+
+
+@article {yayon2023,
 	author = {Nadav Yayon and Veronika R. Kedlian and Lena Boehme and Chenqu Suo and Brianna Wachter and
                   Rebecca T. Beuschel and Oren Amsalem and Krzysztof Polanski and Simon Koplev and Elizabeth Tuck and
                   Emma Dann and Jolien Van Hulle and Shani Perera and Tom Putteman and Alexander V. Predeus and


### PR DESCRIPTION
Adding
T. Kudo et al., "Highly multiplexed, image-based pooled screens in primary cells and tissues with PerturbView".
J. Gu et al. "CRISPRmap: Sequencing-free optical pooled screens mapping multi-omic phenotypes in cells and tissue".