### PR TITLE
Adding publication.

### DIFF
--- a/data/publications.bib
+++ b/data/publications.bib
@@ -1,3 +1,18 @@
+@article {lee2024,
+	author = {Colin Y. C. Lee and Bethany C. Kennedy and Nathan Richoz and Isaac Dean and Zewen K. Tuong
+                  and Fabrina Gaspal and Zhi Li and Claire Willis and Tetsuo Hasegawa and Sarah K. Whiteside
+                  and David A. Posner and Gianluca Carlesso and Scott A. Hammond and Simon J. Dovedi and Rahul Roychoudhuri
+                  and David R. Withers and Menna R. Clatworthy},
+	title = {Tumour-retained activated {CCR7$^+$} dendritic cells are heterogeneous and regulate local anti-tumour cytolytic activity},
+	year = {2024},
+        volume  = {15},
+	number  = {1},
+	doi = {10.1038/s41467-024-44787-1},
+	journal = {Nat Commun},
+	note={Corresponding authors: \href{mailto:d.withers@bham.ac.uk,mrc38@medschl.cam.ac.uk}{David R. Withers, Menna R. Clatworthy}},
+    keywords = {}
+}
+
 @article {kudo2023,
 	author = {Takamasa Kudo and Ana M. Meireles and Reuben Moncada and Yushu Chen and Ping Wu and Joshua Gould and Xiaoyu Hu and Opher Kornfeld and Rajiv Jesudason and Conrad Foo and Burkhard H{\"o}ckendorf and Hector Corrada Bravo and Jason P. Town and Runmin Wei and Antonio Rios and Vineethkrishna Chandrasekar and Melanie Heinlein and Shuangyi Cai and Cherry Sakura Lu and Cemre Celen and Noelyn Kljavin and Jian Jiang and Jose Sergio Hleap and Nobuhiko Kayagaki and Felipe de Sousa e Melo and Lisa McGinnis and Bo Li and Avtar Singh and Levi Garraway and Orit Rozenblatt-Rosen and Aviv Regev and Eric Lubeck},
 	title = {Highly multiplexed, image-based pooled screens in primary cells and tissues with {PerturbView}},


### PR DESCRIPTION
Adding Lee et al, "Tumour-retained activated {CCR7$^+$} dendritic cells are heterogeneous and regulate local anti-tumour cytolytic activity".