### PR TITLE
Add missing validation in the videos json configuration.

### DIFF
--- a/.github/data_validation_configs/videos.json
+++ b/.github/data_validation_configs/videos.json
@@ -17,5 +17,11 @@
    ],
    "url_columns":[
       "URL"
-   ]
+   ],
+   "column_is_in":{
+      "Category":[
+          "general",
+          "tutorial"
+       ]
+   }
 }


### PR DESCRIPTION
The "Category" column in the videos csv file can only have one of two values, "general" or "tutorial". Update the validation JSON configuration file to reflect this.