### PR TITLE
Add link to list of testes fluorescent probes to landing page.

### DIFF
--- a/docs_in/index.md.in
+++ b/docs_in/index.md.in
@@ -17,7 +17,7 @@ layout: default
         <tr>
             <td style="text-align:center;vertical-align: middle"><p style="font-family:verdana;font-size:x-large">Contributors</p></td>
             <td style="text-align:center;vertical-align: middle"><p style="font-family:verdana;font-size:x-large">Community Validated<br>Reagents</p></td>
-            <td style="text-align:center;vertical-align: middle"><p style="font-family:verdana;font-size:x-large">Fluorescent Probes<br>Tested</p></td>
+            <td style="text-align:center;vertical-align: middle"><a href="https://ibeximagingcommunity.github.io/ibex_imaging_knowledge_base/fluorescent_probes.html"><p style="font-family:verdana;font-size:x-large">Fluorescent Probes<br>Tested</p></a></td>
             <td style="text-align:center;vertical-align: middle"><p style="font-family:verdana;font-size:x-large">Tissues</p></td>
         </tr>
     </tbody>


### PR DESCRIPTION
Added a link to the fluorescent probes information directly from the landing page table which lists the numbers for the validated reagents.