### PR TITLE
Adding journal version of Kothurkar et al.

### DIFF
--- a/data/publications.bib
+++ b/data/publications.bib
@@ -141,6 +141,16 @@ note = {Corresponding authors: \href{mailto:skaech@salk.edu}{Susan M. Kaech}}
               keywords = {}
     }
 
+@article {kothurkar2024b,
+	author = {Aanandita Kothurkar and Gregory S. Patient and Nicole C. L. Noel  and Aleksandra M. Krzywa{\'n}ska and Brittany J. Carr  and Colin J. Chu and Ryan B. MacDonald},
+	title = {Iterative Bleaching Extends Multiplexity {(IBEX)} imaging facilitates simultaneous identification of all cell types in the vertebrate retina},
+	year = {2024},
+	doi = {10.1242/jcs.263407},
+	journal = {J. Cell Sci.},
+	note={Corresponding authors: \href{mailto:colin.chu@ucl.ac.uk,ryan.macdonald@ucl.ac.uk}{Colin J. Chu, Ryan B. MacDonald}},
+	keywords = {}
+}
+
 @article {kothurkar2024,
 	author = {Aanandita Kothurkar and Gregory S. Patient and Nicole C. L. Noel and Colin J. Chu and Ryan B. MacDonald},
 	title = {Iterative Bleaching Extends Multiplexity {(IBEX)} imaging facilitates simultaneous identification of all cell types in the vertebrate retina},


### PR DESCRIPTION
Adding the journal version of the manuscript titled "Iterative Bleaching Extends Multiplexity (IBEX) imaging facilitates simultaneous identification of all cell types in the vertebrate retina"