### PR TITLE
Missing newline in markdown caused problem with table rendering.

### DIFF
--- a/docs/supporting_material/SIRPalpha_AF647/0009-0007-0646-7946.md
+++ b/docs/supporting_material/SIRPalpha_AF647/0009-0007-0646-7946.md
@@ -16,6 +16,7 @@ layout: default
 
 <a name="notes"></a>
 1. Very bright, recommend dilution 1:200.
+
 | Mouse tumor: Cytokeratin (yellow, catalog number 628608) and SIRPalpha (white, catalog number 144027) |
 |:-------:|
 | ![](../Cytokeratin_AF488/Mouse_tumor_Cytokeratin_628608_SIRPalpha_144027.jpg) |


### PR DESCRIPTION
Table with image was rendered incorrectly because there was a missing newline before the table.

resolves #250