### PR TITLE
Pin the minima theme to a specific hash.

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-remote_theme: jekyll/minima
+remote_theme: "jekyll/minima@1e8a445"
 
 title: IBEX Imaging Community
 


### PR DESCRIPTION
The developers of the minima theme are refactoring it and recommend pinning: "The master branch is under active development towards a semver-major release with non-backwards-compatible changes."

Once they finish development will need to unpin and refactor the contents of the KB settings files to use the new configuration options.