### PR TITLE
Update paths to icons.

### DIFF
--- a/docs/assets/image/browserconfig.xml
+++ b/docs/assets/image/browserconfig.xml
@@ -1,8 +1,10 @@
+---
+---
 <?xml version="1.0" encoding="utf-8"?>
 <browserconfig>
     <msapplication>
         <tile>
-            <square150x150logo src="/assets/image/mstile-150x150.png"/>
+            <square150x150logo src="{{ site.baseurl }}/assets/image/mstile-150x150.png"/>
             <TileColor>#da532c</TileColor>
         </tile>
     </msapplication>

--- a/docs/assets/image/site.webmanifest
+++ b/docs/assets/image/site.webmanifest
@@ -1,14 +1,16 @@
+---
+---
 {
-    "name": "",
-    "short_name": "",
+    "name": "IBEX Imaging Community",
+    "short_name": "IBEX",
     "icons": [
         {
-            "src": "/assets/image/android-chrome-192x192.png",
+            "src": "{{ site.baseurl }}/assets/image/android-chrome-192x192.png",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "/assets/image/android-chrome-512x512.png",
+            "src": "{{ site.baseurl }}/assets/image/android-chrome-512x512.png",
             "sizes": "512x512",
             "type": "image/png"
         }


### PR DESCRIPTION
The paths to the favicons in the browserconfig.xml and site.webmanifest files were incorrect,
missing the `{{ site.baseurl }}` prefix.
This commit updates the paths to point to the correct location of the icons in the image directory.